### PR TITLE
Test/FrmPkg: Fix the boot failure if guest OS has kernel 4.12 or newer.

### DIFF
--- a/Test/FrmPkg/Core/Init/VmcsInit.c
+++ b/Test/FrmPkg/Core/Init/VmcsInit.c
@@ -84,7 +84,7 @@ SetVmcsControlField (
   ProcessorBasedCtrls.Bits.InterruptWindow = 0; // interrupt window
   ProcessorBasedCtrls.Bits.NmiWindow = 0;
   ProcessorBasedCtrls.Bits.IoBitmap = 1;
-  ProcessorBasedCtrls.Bits.MsrBitmap = 0;
+  ProcessorBasedCtrls.Bits.MsrBitmap = 1;
   ProcessorBasedCtrls.Bits.SecondaryControl = 1;
 
   Data64 = AsmReadMsr64 (IA32_VMX_PROCBASED_CTLS2_MSR_INDEX);


### PR DESCRIPTION
Linux kernel(4.12, and newer) reads MSR 0x140, MSR_XEON_PHI_MISC_FEATURE_ENABLES_REGISTER
and it causes CPU hang if CPU is in VMM mode.

Solution: Set MsrBitmap to 1 and set the corresponding bits in
mGuestContextCommon.MsrBitmap. Make VMM service the MSR read/write
requests only if the MSR handler is  defined in MsrHandler.c.

Testing: Verified pass with Minnowboard max.