### PR TITLE
Correct some issues in creating a protected execution VM

### DIFF
--- a/Stm/StmPkg/Core/Dump.c
+++ b/Stm/StmPkg/Core/Dump.c
@@ -447,6 +447,9 @@ DumpVmcsAllField (
   UINT32 CpuIndex
   )
 {
+  UINT64 VMCS;
+  AsmVmPtrStore (&VMCS);
+  DEBUG((EFI_D_ERROR, "%d DumpVmcsAllField - VMCS: %016llx\n", CpuIndex, VMCS));
   DumpVmcsControlField (CpuIndex);
   DumpVmcsReadOnlyField (CpuIndex);
   DumpVmcsGuestField (CpuIndex);

--- a/Stm/StmPkg/Core/Init/PeVmcsInit.c
+++ b/Stm/StmPkg/Core/Init/PeVmcsInit.c
@@ -124,12 +124,21 @@ InitPeGuestVmcs (
   if (ProcessorBasedCtrls.Bits.IoBitmap != 0) 
   {
 	 // Since we want to use IO Bitmaps, then point to the Bitmaps
-    VmWrite64 (VMCS_64_CONTROL_IO_BITMAP_A_INDEX,                    mGuestContextCommonSmm[VmType].IoBitmapA);
-    VmWrite64 (VMCS_64_CONTROL_IO_BITMAP_B_INDEX,                    mGuestContextCommonSmm[VmType].IoBitmapB);
+    VmWrite64 (VMCS_64_CONTROL_IO_BITMAP_A_INDEX, mGuestContextCommonSmm[VmType].IoBitmapA);
+    VmWrite64 (VMCS_64_CONTROL_IO_BITMAP_B_INDEX, mGuestContextCommonSmm[VmType].IoBitmapB);
+  }
+  else
+  {
+    VmWrite64 (VMCS_64_CONTROL_IO_BITMAP_A_INDEX, 0);
+    VmWrite64 (VMCS_64_CONTROL_IO_BITMAP_B_INDEX, 0);
   }
 
   if (ProcessorBasedCtrls.Bits.MsrBitmap != 0) {
-    VmWrite64 (VMCS_64_CONTROL_MSR_BITMAP_INDEX,                     mGuestContextCommonSmm[VmType].MsrBitmap);
+    VmWrite64 (VMCS_64_CONTROL_MSR_BITMAP_INDEX, mGuestContextCommonSmm[VmType].MsrBitmap);
+  }
+  else
+  {
+    VmWrite64 (VMCS_64_CONTROL_MSR_BITMAP_INDEX, 0);
   }
 
   //

--- a/Stm/StmPkg/Core/Init/StmInit.c
+++ b/Stm/StmPkg/Core/Init/StmInit.c
@@ -1270,7 +1270,6 @@ LaunchBack (
 
 **/
 
-extern void PrintSmiEnRegister(UINT32 Index); // found in PcPciHandler.c
 VOID
 InitializeSmmMonitor (
   IN X86_REGISTER *Register
@@ -1289,13 +1288,11 @@ InitializeSmmMonitor (
     Index = GetIndexFromStack (Register);
     ApInit (Index, Register);
   }
-  //PrintSmiEnRegister(Index);    /* debug*/
 
   CommonInit (Index);
 
   VmcsInit (Index);
    //
-  PrintSmiEnRegister(Index);   /* DEBUG*/
   AsmWbinvd();  // flush caches
   LaunchBack (Index);
   return ;

--- a/Stm/StmPkg/Core/Runtime/PeEptHandler.c
+++ b/Stm/StmPkg/Core/Runtime/PeEptHandler.c
@@ -34,11 +34,13 @@ Setup VM/PE EPT tables.
 #define memcpy CopyMem
 
 extern UINT8 GetMemoryType (IN UINT64 BaseAddress);  // call to base EPT functionality - hope to eventually do more of this
+extern int strlen1(const char *str);
 extern UINT64 EndTimeStamp;
 
 static void PeEptFreeL2(IN UINT64 Level2);
 static void insertPhysAdd(EPT_ENTRY* L1PageTable, UINTN startAddress, UINTN StartIndex, UINTN size);
 extern UINT32 PostPeVmProc(UINT32 rc, UINT32 CpuIndex, UINT32 mode);
+extern UINT32 EventInjection (UINT32 Index, VM_EXIT_INFO_INTERRUPTION IntInfo, UINT32 IntErr);
 
 extern VOID
 EptCreatePageTable (
@@ -124,8 +126,8 @@ void PeEPTViolationHandler( IN UINT32 CpuIndex)
 
 	//Line[0] = '\0';
 #define Message1 "PeEPTViolationHandler - Access Allowed: "
-        int count = sizeof(Message1);
-        memcpy(Line, Message1, count - 1);
+        int count = strlen1(Message1);
+        memcpy(Line, Message1, count);
         memcpy(&Line[count], AccessAllowed, 3);
         count = count + 3;
         Line[count] = '\n';
@@ -153,9 +155,9 @@ void PeEPTViolationHandler( IN UINT32 CpuIndex)
 
 	///Line[0] = '\0';
 #define Message2 "PeEPTViolationHandler - Access Attempted causing Violation: "
-        count = sizeof(Message2);
+        count = strlen1(Message2);
 	//sprintf(Line, "%ld PeEPTViolationHandler - Access Attempted: %s\n", CpuIndex, AccessRequested);
-	memcpy(Line, Message2, count - 1 ); // account for null
+	memcpy(Line, Message2, count ); // account for null
 	memcpy(&Line[count], AccessRequested, 3);
         count = count + 3;
         Line[count] = '\n';
@@ -169,9 +171,9 @@ void PeEPTViolationHandler( IN UINT32 CpuIndex)
 		LinearAddressValid = "Invalid";
 	//Line[0] = '\0';
 #define Message3 "PeEPTViolationHandler - Linear address is "
-	count = sizeof(Message3);
+	count = strlen1(Message3);
         memcpy(Line, Message3, count);
-        memcpy(&Line[count], LinearAddressValid, 7);
+        memcpy(&Line[count], LinearAddressValid, strlen1(LinearAddressValid));
         count = count + 7;
         Line[count] = '\n';
         Line[count + 1] = '\0';
@@ -189,9 +191,9 @@ void PeEPTViolationHandler( IN UINT32 CpuIndex)
 
     //Line[0] = '\0';
 	//sprintf(Line, "%ld PeEPTViolationHandler - Linear address is %s\n", CpuIndex, AddressViolation);
-	count = sizeof(Message3);
+	count = strlen1(Message3);
         memcpy(Line, Message3, count);
-        memcpy(&Line[count], AddressViolation, 28);
+        memcpy(&Line[count], AddressViolation, strlen1(AddressViolation));
         count = count + 28;
         Line[count] = '\n';
         Line[count + 1] = '\0';

--- a/Stm/StmPkg/Core/Runtime/PeLoadVm.c
+++ b/Stm/StmPkg/Core/Runtime/PeLoadVm.c
@@ -261,7 +261,6 @@ void LaunchPeVm(UINT32 PeType, UINT32 CpuIndex)
 			(UINTN)VmRead32 (VMCS_32_RO_VM_INSTRUCTION_ERROR_INDEX)));
 	DumpVmcsAllField (CpuIndex);
 	DumpRegContext (&mGuestContextCommonSmm[PeType].GuestContextPerCpu[0].Register, CpuIndex);
-	DumpGuestStack(CpuIndex);
 	ReleaseSpinLock (&mHostContextCommon.DebugLock);
 }
 
@@ -372,7 +371,6 @@ UINT32  PostPeVmProc(UINT32 rc, UINT32 CpuIndex, UINT32 mode)
 		DumpVmcsAllField(CpuIndex);   //  temp debug
 		DumpVmxCapabillityMsr(CpuIndex);
 		DumpRegContext(&mGuestContextCommonSmm[PeType].GuestContextPerCpu[0].Register, CpuIndex);
-		DumpGuestStack(CpuIndex);
 		print_region_list(PeType, CpuIndex);
 
 		if((PERM_VM_CRASH_BREAKDOWN & PeVmData[PeType].UserModule.VmConfig) == PERM_VM_CRASH_BREAKDOWN)

--- a/Stm/StmPkg/Core/Runtime/PePciHandler.c
+++ b/Stm/StmPkg/Core/Runtime/PePciHandler.c
@@ -52,6 +52,9 @@ void SetTimerRate(UINT16 value);
 	(((DEV) & 0x1F) << 15) | \
 	(((FN) & 0x07) <<12))
 
+void PrintSmiEnRegister(UINT32 Index);
+extern STM_GUEST_CONTEXT_COMMON        mGuestContextCommonSmm[];
+
 typedef int device_t;
 
 static UINT16 pmbase = 0x0;
@@ -106,7 +109,25 @@ static device_t get_pcu_dev(void)
 
 UINT16 get_pmbase(void)
 {
-	return pcie_read_config16(get_pcu_dev(), D31F0_PMBASE ) & 0xFFF8;
+	if (pmbase == 0)
+	{
+		// find the pmbase in the BIOS resource list
+
+		STM_RSC *Resource;
+
+		// the pmbase is the first IO resource
+		Resource = GetStmFirstResource (
+				(STM_RSC *)mGuestContextCommonSmm[SMI_HANDLER].BiosHwResourceRequirementsPtr,
+				IO_RANGE);
+		if(Resource == NULL)
+			DEBUG((EFI_D_ERROR, "get_pmbase - Error pmbase not found in resource list\n"));
+		else
+		{
+			pmbase = Resource->Io.Base;
+			DEBUG((EFI_D_INFO, "get_pmbase - pmbase set at 0x%x\n", pmbase));
+		}
+	}
+	return pmbase;
 } 
 
 void StartTimer(void)
@@ -117,8 +138,7 @@ void StartTimer(void)
 
 	smi_en |= PERIODIC_EN;
 
-	//DEBUG((EFI_D_ERROR, "-- StartSwTimer pmbase: %x smi_en: %x \n", pmbase, smi_en));
-	DEBUG((EFI_D_ERROR, "StartTimer - smi_en: 0x%08lx smi_sts: 0x%08lx\n", smi_en, smi_sts));
+	//DEBUG((EFI_D_INFO, "StartTimer - smi_en: 0x%08lx smi_sts: 0x%08lx\n", smi_en, smi_sts));
 	IoWrite32(pmbase + SMI_STS, PERIODIC_STS);
 	IoWrite32(pmbase + SMI_EN, smi_en);
 }
@@ -130,18 +150,17 @@ void SetEndOfSmi(void)
 	UINT32 smi_en = IoRead32(pmbase + SMI_EN);
 	smi_en |= EOS_EN;  // set the bit
 
-	//DEBUG((EFI_D_ERROR, "-- StartSwTimer pmbase: %x smi_en: %x \n", pmbase, smi_en));
-	//DEBUG((EFI_D_ERROR, "-- SW Timer Started - smi_en: 0x%08lx smi_sts: 0x%08lx\n", smi_en, smi_sts));
+	//DEBUG((EFI_D_INFO, "-- SetEndOfSmi pmbase: %x smi_en: %x \n", pmbase, smi_en));
 
 	IoWrite32(pmbase + SMI_EN, smi_en);
-	DEBUG((EFI_D_ERROR, "SetEndOfSmi smi_en: 0x%08lx smi_sts: 0x%08lx\n", IoRead32(pmbase + SMI_EN), IoRead32(pmbase + SMI_STS)));
+	//DEBUG((EFI_D_INFO, "SetEndOfSmi smi_en: 0x%08lx smi_sts: 0x%08lx\n", IoRead32(pmbase + SMI_EN), IoRead32(pmbase + SMI_STS)));
 
 }
 
 void PrintSmiEnRegister(UINT32 Index)
 {
 	UINT16 pmbase = get_pmbase();
-	DEBUG((EFI_D_ERROR, "%ld PrintSmiEnRegister smi_en: 0x%08x smi_sts: 0x%08x\n", Index, IoRead32(pmbase + SMI_EN), IoRead32(pmbase + SMI_STS)));
+	DEBUG((EFI_D_INFO, "%ld PrintSmiEnRegister smi_en: 0x%08x smi_sts: 0x%08x\n", Index, IoRead32(pmbase + SMI_EN), IoRead32(pmbase + SMI_STS)));
 }
 
 void AckTimer(void)
@@ -150,7 +169,7 @@ void AckTimer(void)
 	
 	IoWrite32(pmbase + SMI_STS, PERIODIC_STS);
 	
-	DEBUG((EFI_D_ERROR, "AckTimer - smi_en: 0x%08lx smi_sts: 0x%08lx\n", IoRead32(pmbase + SMI_EN), IoRead32(pmbase + SMI_STS)));
+	//DEBUG((EFI_D_INFO, "AckTimer - smi_en: 0x%08lx smi_sts: 0x%08lx\n", IoRead32(pmbase + SMI_EN), IoRead32(pmbase + SMI_STS)));
 }
 
 void StopSwTimer(void)
@@ -160,9 +179,6 @@ void StopSwTimer(void)
 
 	smi_en &= ~PERIODIC_EN;
 	IoWrite32(pmbase + SMI_EN, smi_en);
-	
-	//DEBUG((EFI_D_ERROR, "-- SW Timer Stopped - pre-smi_en %x post-smi_en: %x\n", pre_smi_en, post_smi_en));
-	DEBUG((EFI_D_ERROR, "StopSwTimer - smi_en: 0x%08lx smi_sts: 0x%08lx\n", IoRead32(pmbase + SMI_EN), IoRead32(pmbase + SMI_STS)));
 }
 
 int CheckTimerSTS(UINT32 Index)
@@ -174,12 +190,12 @@ int CheckTimerSTS(UINT32 Index)
 
 	if((smi_sts & PERIODIC_STS) == PERIODIC_STS)
 	{
-		DEBUG((EFI_D_ERROR, "%ld CheckTimerSTS - Timer Interrupt Detected\n", Index, smi_sts));
+		DEBUG((EFI_D_INFO, "%ld CheckTimerSTS - Timer Interrupt Detected\n", Index, smi_sts));
 		return 1;
 	}
 	else
 	{
-		//DEBUG((EFI_D_ERROR, "%ld CheckTimerSTS - No Timer Interrupt Detected\n", Index, smi_sts));
+		//DEBUG((EFI_D_INFO "%ld CheckTimerSTS - No Timer Interrupt Detected\n", Index, smi_sts));
 		return 0;
 	}
 }

--- a/Stm/StmPkg/Core/Runtime/PeSmmMsrHandler.c
+++ b/Stm/StmPkg/Core/Runtime/PeSmmMsrHandler.c
@@ -36,16 +36,14 @@ PeReadMsrHandler (
   UINT64            Data64;
   UINT32            MsrIndex;
   X86_REGISTER      *Reg;
-  STM_SMM_CPU_STATE *SmmCpuState;
-  UINT32			VmType = PE_PERM;
+  UINT32	    VmType = mHostContextCommon.HostContextPerCpu[CpuIndex].GuestVmType;
 
   UINT32 Index = 0;   // PE/VM only has index as 0
 
-  SmmCpuState = mGuestContextCommonSmi.GuestContextPerCpu[Index].SmmCpuState;
   Reg = &mGuestContextCommonSmm[VmType].GuestContextPerCpu[Index].Register;
   MsrIndex = ReadUnaligned32 ((UINT32 *)&Reg->Rcx);
 
-  DEBUG ((EFI_D_INFO, "%ld ReadMsrHandler - 0x%llx\n", CpuIndex, MsrIndex));
+  DEBUG ((EFI_D_INFO, "%ld PeReadMsrHandler - 0x%llx\n", CpuIndex, MsrIndex));
 
   switch (MsrIndex) {
   case IA32_EFER_MSR_INDEX:
@@ -101,7 +99,7 @@ PeWriteMsrHandler (
   VM_ENTRY_CONTROLS VmEntryControls;
   X86_REGISTER      *Reg;
   STM_SMM_CPU_STATE *SmmCpuState;
-  UINT32			VmType = PE_PERM;
+  UINT32            VmType = mHostContextCommon.HostContextPerCpu[CpuIndex].GuestVmType;
   
   UINT32 Index = 0;        // PE VM only Index = 0
 
@@ -111,7 +109,7 @@ PeWriteMsrHandler (
   MsrIndex = ReadUnaligned32 ((UINT32 *)&Reg->Rcx);
 
   Data64 = LShiftU64 ((UINT64)ReadUnaligned32 ((UINT32 *)&Reg->Rdx), 32) | (UINT64)ReadUnaligned32 ((UINT32 *)&Reg->Rax);
-  DEBUG ((EFI_D_INFO, "%ld WriteMsrHandler - 0x%llx 0x%llx\n", CpuIndex, MsrIndex, Data64));
+  DEBUG ((EFI_D_INFO, "%ld PeWriteMsrHandler - 0x%llx 0x%llx\n", CpuIndex, MsrIndex, Data64));
 
   switch (MsrIndex) {
   case IA32_EFER_MSR_INDEX:

--- a/Stm/StmPkg/Core/Runtime/PeVmxState.c
+++ b/Stm/StmPkg/Core/Runtime/PeVmxState.c
@@ -250,6 +250,7 @@ VmcsFlushStart:
 		// release the buffers
 		for(i = 0; i < FlushCount; i++)
 		{
+			AsmVmClear((UINT64 *) &DummyVmcs[i]);
 			FreePages(DummyVmcs[i], VmcsSizeInPages);
 		}
 	}

--- a/Stm/StmPkg/Core/Runtime/SmiEventHandler.c
+++ b/Stm/StmPkg/Core/Runtime/SmiEventHandler.c
@@ -60,14 +60,16 @@ SmiEventHandler (
     WriteSyncSmmStateSaveArea (Index);
     STM_PERF_END (Index, "WriteSyncSmmStateSaveArea", "SmiEventHandler");
 
+    AsmVmPtrStore (&mGuestContextCommonSmi.GuestContextPerCpu[Index].Vmcs);
+
     if(PeSmiHandler(Index) == 1)
     {
+	AsmVmPtrLoad (&mGuestContextCommonSmi.GuestContextPerCpu[Index].Vmcs);
         return;
     }
 #if 0
 		DEBUG((EFI_D_ERROR, "%ld SmiEventHandler - Starting SMI handler\n", Index));
 #endif
-	AsmVmPtrStore (&mGuestContextCommonSmi.GuestContextPerCpu[Index].Vmcs);
     Rflags = AsmVmPtrLoad (&mGuestContextCommonSmm[SMI_HANDLER].GuestContextPerCpu[Index].Vmcs);
     if ((Rflags & (RFLAGS_CF | RFLAGS_ZF)) != 0) {
         DEBUG ((EFI_D_ERROR, "ERROR: AsmVmPtrLoad(%d) - %016lx : %08x\n", (UINTN)Index, mGuestContextCommonSmm[SMI_HANDLER].GuestContextPerCpu[Index].Vmcs, Rflags));

--- a/Stm/StmPkg/Core/Runtime/SmiVmcallHandler.c
+++ b/Stm/StmPkg/Core/Runtime/SmiVmcallHandler.c
@@ -175,8 +175,6 @@ SmiVmcallProtectResourceHandler (
 
   StmResource = (STM_RSC *)(UINTN)LocalBuffer;
 
-  DumpStmResource (StmResource);
-
   if (!IsResourceListValid (StmResource, TRUE)) {
     DEBUG ((EFI_D_ERROR, "IsResourceListValid fail!\n"));
     RawFreeResource (LocalBuffer);
@@ -252,8 +250,6 @@ SmiVmcallUnprotectResourceHandler (
     return ERROR_STM_MALFORMED_RESOURCE_LIST;
   }
   DEBUG ((EFI_D_INFO, "IsResourceListValid pass!\n"));
-
-  DumpStmResource (StmResource);
 
   DeleteProtectedResource (&mHostContextCommon.MleProtectedResource, StmResource);
 

--- a/Stm/StmPkg/Core/Runtime/StmRuntime.h
+++ b/Stm/StmPkg/Core/Runtime/StmRuntime.h
@@ -570,6 +570,23 @@ RegisterBiosResource (
   IN STM_RSC   *Resource
   );
 
+/**^M
+^M
+  This function returns the first STM resource of resource type.^M
+^M
+  @param Resource STM resource list^M
+  @param RscType  resource type
+^M
+  @return STM resource^M
+^M
+**/
+
+STM_RSC *
+GetStmFirstResource (
+  IN STM_RSC   *Resource,
+  IN UINT16    RscType
+  );
+
 /**
 
   This function translate guest linear address to guest physical address.
@@ -616,6 +633,7 @@ LookupSmiGuestVirtualToGuestPhysical (
 
   @retval TRUE  HostPhysicalAddress is found
   @retval FALSE HostPhysicalAddress is not found
+
 **/
 BOOLEAN
 LookupSmiGuestPhysicalToHostPhysical (

--- a/Stm/StmPkg/Core/Runtime/VmcsMapper.c
+++ b/Stm/StmPkg/Core/Runtime/VmcsMapper.c
@@ -302,8 +302,8 @@ int strlen1(const char *str)
 {
 	const char * s;
 	int counter = 0;
-	for (s=str; (*s != 0) && (counter < 40); ++s, ++counter);
-	return counter;  // only try 40
+	for (s=str; (*s != 0) && (counter < 70); ++s, ++counter);
+	return counter;  // only try 70
 }
 
 static UINT32 VmcsMapInit = 0;  // used to trigger VmcsMap initialization

--- a/Stm/StmPkg/Core/Runtime/VmcsMapper.c
+++ b/Stm/StmPkg/Core/Runtime/VmcsMapper.c
@@ -375,7 +375,7 @@ void MapVmcs ()
 	}
 
 	AsmVmPtrLoad(&CurrentVMCSSave);       // Put back the orignal Vmcs
-	AsmVmClear((UINT64 *)EvalVmcs);
+	AsmVmClear((UINT64 *)&EvalVmcs);
 
 	FreePages(EvalVmcs, VmcsSizeInPages);                  // free up the eval vmcs
 

--- a/Stm/StmPkg/Core/Runtime/x64/PeVmExit.S
+++ b/Stm/StmPkg/Core/Runtime/x64/PeVmExit.S
@@ -38,7 +38,7 @@ ASM_PFX(AsmHostEntrypointSmmPe):
   push %rcx
   push %rax
   movq %rsp, %rcx # parameter for MS
-  movq %rdi, %rdi # parameter for GCC
+  movq %rsp, %rdi # parameter for GCC
   subq $0x30, %rsp
   call ASM_PFX(PeStmHandlerSmm)
   addq $0x30, %rsp

--- a/Stm/StmPkg/Core/Runtime/x64/PeVmExit.asm
+++ b/Stm/StmPkg/Core/Runtime/x64/PeVmExit.asm
@@ -39,7 +39,8 @@ AsmHostEntrypointSmmPe PROC PUBLIC
   push rdx
   push rcx
   push rax
-  mov  rcx, rsp ; parameter
+  mov  rcx, rsp ; parameter (MS)
+  mov  rdi, rsp : parameter (GCC)
   sub  rsp, 20h
   call PeStmHandlerSmm
   add  rsp, 20h

--- a/Stm/StmPkg/Core/Runtime/x64/VmExit.asm
+++ b/Stm/StmPkg/Core/Runtime/x64/VmExit.asm
@@ -39,7 +39,8 @@ AsmHostEntrypointSmi PROC PUBLIC
   push rdx
   push rcx
   push rax
-  mov  rcx, rsp ; parameter
+  mov  rcx, rsp ; parameter (MS)
+  mov  rdi, rsp : parameter (GCC)
   sub  rsp, 20h
   call StmHandlerSmi
   add  rsp, 20h

--- a/Stm/StmPkg/Core/StmResource.c
+++ b/Stm/StmPkg/Core/StmResource.c
@@ -1922,4 +1922,37 @@ RegisterBiosResource (
     RegisterBiosResource ((STM_RSC *)(UINTN)Resource->End.ResourceListContinuation);
   }
 }
+/**^M
+^M
+  This function returns the first STM resource of resource type.^M
+^M
+  @param Resource STM resource list^M
+  @param RscType  resource type
+^M
+  @return STM resource^M
+^M
+**/
+
+STM_RSC *
+GetStmFirstResource (
+  IN STM_RSC   *Resource,
+  IN UINT16    RscType
+  )
+{
+  if (Resource == NULL) {
+    return NULL;
+  }
+  while (Resource->Header.RscType != END_OF_RESOURCES) {
+    if ((Resource->Header.IgnoreResource == 0) &&
+        (Resource->Header.RscType == RscType)) {
+      return Resource;
+	}
+    Resource = (STM_RSC *)((UINTN)Resource + Resource->Header.Length);
+  }
+  if (Resource->End.ResourceListContinuation != 0) {
+    return GetStmFirstResource ((STM_RSC *)(UINTN)Resource->End.ResourceListContinuation, RscType);
+  }
+
+  return NULL;
+}
 


### PR DESCRIPTION
These patches correct a problem in starting a PE/VM where there is apparent corruption
 in the VMCS.  This is caused by a missing '&' when the AsmVmCall is made when releasing the dummy VMCS resulting in the VMCS not being cleared.  The second issue was caused
by the vmexit handler not setting the C parameter passing properly.  All the AsmVmExit modules have to be able to handle the MSC and GCC calling conventions.  This patch corrects this issue.